### PR TITLE
chore: restrict SDK auto-merge to same-repo branches

### DIFF
--- a/.github/workflows/stlc-auto-merge.yml
+++ b/.github/workflows/stlc-auto-merge.yml
@@ -46,15 +46,22 @@ jobs:
 
           for pr in "${pr_numbers[@]}"; do
             echo "Evaluating PR #$pr"
-            pr_json=$(gh pr view "$pr" --repo "$REPO" --json title,isDraft,headRefName,headRefOid,baseRefName,mergeStateStatus)
+            pr_json=$(gh pr view "$pr" --repo "$REPO" --json title,isDraft,headRefName,headRefOid,headRepository,isCrossRepository,baseRefName,mergeStateStatus)
             title=$(jq -r '.title' <<<"$pr_json")
             is_draft=$(jq -r '.isDraft' <<<"$pr_json")
             head_ref=$(jq -r '.headRefName' <<<"$pr_json")
             head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
+            head_repo=$(jq -r '.headRepository.nameWithOwner // ""' <<<"$pr_json")
+            is_cross_repository=$(jq -r '.isCrossRepository' <<<"$pr_json")
             base_ref=$(jq -r '.baseRefName' <<<"$pr_json")
 
             if [ "$base_ref" != "main" ] || [ "$is_draft" = "true" ]; then
               echo "Skipping PR #$pr: not a ready PR to main."
+              continue
+            fi
+
+            if [ "$is_cross_repository" = "true" ] || [ "$head_repo" != "$REPO" ]; then
+              echo "Skipping PR #$pr: head branch is not in $REPO."
               continue
             fi
 


### PR DESCRIPTION
Adds an explicit same-repo guard to the stlc auto-merge workflow so pull_request_target events cannot evaluate forked PR heads, even if a fork uses the automated branch/title convention.\n\nValidation:\n- YAML parsed locally\n- embedded bash parsed locally with GitHub expressions stubbed\n- prettier check passed