### PR TITLE
Disable code-execution tool on hosted MCP deployment only (--no-tools=code)

### DIFF
--- a/.github/workflows/deploy-mcp-server.yml
+++ b/.github/workflows/deploy-mcp-server.yml
@@ -108,7 +108,7 @@ jobs:
                   }
                 ],
                 "essential": true,
-                "command": ["--transport=http", "--port=3000"],
+                "command": ["--transport=http", "--port=3000", "--no-tools=code"],
                 "environment": [],
                 "secrets": [],
                 "logConfiguration": {


### PR DESCRIPTION
## Why

The hosted multi-tenant MCP server (mcp.retellai.com) must not expose the arbitrary-code `execute` tool (P00). Disabling it globally in the Stainless config also strips it from the published npm package that local users self-run — which we don't want. This scopes the disable to the **hosted ECS deployment** via `--no-tools=code`. Local users keep the code tool (safe: their own machine, their own key).

Pairs with reverting `enable_code_tool` to `true` in the docs repo Stainless config.

## ⚠️ Merge sequencing (important)

`--no-tools=code` is only valid on a build where the code tool is generated. The current live build (`5.41.0`, docs-only) has `--no-tools` choices `['docs']` only, so this flag would be **rejected → server crash on startup**.

Recommended order:
1. **Merge this SDK PR first.** The deploy it triggers builds the current `5.41.0` image + this flag → new tasks fail startup → ECS keeps the existing (docs-only, safe) tasks running; the deploy fails loudly but **hosted stays up and safe** (still docs-only, no RCE). Verify `mcp.retellai.com/health` still 200 + `tools/list` still docs-only.
2. **Then merge the docs config revert PR.** It regenerates `5.42.0` with the code tool back; the deploy uses this workflow (flag already present) → hosted runs docs-only via a now-valid `--no-tools=code`, and the npm package ships the code tool for local users.

This order keeps the hosted server safe throughout (no RCE re-exposure window). The intermediate failed deploy in step 1 is expected and benign.

Note: `deploy-mcp-server.yml` is a preserved production workflow (not regenerated by stlc), so this flag survives future regens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)